### PR TITLE
Correct version for Abaqus

### DIFF
--- a/var/spack/repos/builtin/packages/abaqus/package.py
+++ b/var/spack/repos/builtin/packages/abaqus/package.py
@@ -13,7 +13,7 @@ class Abaqus(Package):
     only_binary = True
 
 
-    version('16.4-1')
+    version('6.14-1')
 
     def install(self, spec, prefix):
         pass


### PR DESCRIPTION
Change of version from 16.4-1 to 6.14-1

