### PR TITLE
A series of changes I've been using to improve external packages

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -99,7 +99,7 @@ class DefaultConcretizer(object):
 
         # Use a sort key to order the results
         return sorted(usable, key=lambda spec: (
-            not (spec.external or spec.external_module),  # prefer externals
+            not spec.external,                            # prefer externals
             pref_key(spec),                               # respect prefs
             spec.name,                                    # group by name
             reverse_order(spec.versions),                 # latest version

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -185,7 +185,7 @@ class YamlDirectoryLayout(DirectoryLayout):
         _check_concrete(spec)
 
         if spec.external:
-            return spec.external
+            return spec.external_path
 
         dir_name = "%s-%s-%s" % (
             spec.name,

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1132,8 +1132,14 @@ class PackageBase(with_metaclass(PackageMeta, object)):
             the user, False if it was pulled in as a dependency of an explicit
             package.
         """
-        message = '{s.name}@{s.version} : externally installed in {path}'
-        tty.msg(message.format(s=self, path=self.spec.external))
+        if self.spec.external_module:
+            message = '{s.name}@{s.version} : has external module in {module}'
+            tty.msg(message.format(s=self, module=self.spec.external_module))
+            message = '{s.name}@{s.version} : is actually installed in {path}'
+            tty.msg(message.format(s=self, path=self.spec.external_path))
+        else:
+            message = '{s.name}@{s.version} : externally installed in {path}'
+            tty.msg(message.format(s=self, path=self.spec.external_path))
         try:
             # Check if the package was already registered in the DB
             # If this is the case, then just exit

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -223,8 +223,6 @@ def spec_externals(spec):
         if not module:
             continue
 
-        path = get_path_from_module(module)
-
         external_spec = spack.spec.Spec(
             external_spec, external=True, external_module=module)
         if external_spec.satisfies(spec):

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -29,6 +29,7 @@ from llnl.util.lang import classproperty
 
 import spack
 import spack.error
+from spack.util.path import canonicalize_path
 from spack.version import *
 
 
@@ -215,7 +216,8 @@ def spec_externals(spec):
             # skip entries without paths (avoid creating extra Specs)
             continue
 
-        external_spec = spack.spec.Spec(external_spec, external_path=path)
+        external_spec = spack.spec.Spec(external_spec,
+                                        external_path=canonicalize_path(path))
         if external_spec.satisfies(spec):
             external_specs.append(external_spec)
 

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -215,7 +215,7 @@ def spec_externals(spec):
             # skip entries without paths (avoid creating extra Specs)
             continue
 
-        external_spec = spack.spec.Spec(external_spec, external=path)
+        external_spec = spack.spec.Spec(external_spec, external=True,  external_path=path)
         if external_spec.satisfies(spec):
             external_specs.append(external_spec)
 
@@ -226,7 +226,7 @@ def spec_externals(spec):
         path = get_path_from_module(module)
 
         external_spec = spack.spec.Spec(
-            external_spec, external=path, external_module=module)
+            external_spec, external=True, external_module=module)
         if external_spec.satisfies(spec):
             external_specs.append(external_spec)
 

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -215,7 +215,7 @@ def spec_externals(spec):
             # skip entries without paths (avoid creating extra Specs)
             continue
 
-        external_spec = spack.spec.Spec(external_spec, external=True,  external_path=path)
+        external_spec = spack.spec.Spec(external_spec, external_path=path)
         if external_spec.satisfies(spec):
             external_specs.append(external_spec)
 
@@ -224,7 +224,7 @@ def spec_externals(spec):
             continue
 
         external_spec = spack.spec.Spec(
-            external_spec, external=True, external_module=module)
+            external_spec, external_module=module)
         if external_spec.satisfies(spec):
             external_specs.append(external_spec)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3009,7 +3009,6 @@ class SpecParser(spack.parse.Parser):
         spec.variants = VariantMap(spec)
         spec.architecture = None
         spec.compiler = None
-        spec.external = False
         spec.external_path = None
         spec.external_module = None
         spec.compiler_flags = FlagMap(spec)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1727,7 +1727,7 @@ class Spec(object):
             if s.namespace is None:
                 s.namespace = spack.repo.repo_for_pkg(s.name).namespace
 
-        for s in self.traverse(root=False):
+        for s in self.traverse():
             if s.external_module:
                 compiler = spack.compilers.compiler_for_spec(
                     s.compiler, s.architecture)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1610,8 +1610,7 @@ class Spec(object):
             for spec in list(self.traverse()):
                 replacement = None
                 if spec.external:
-                    done = True
-                    break
+                    continue
                 if spec.virtual:
                     replacement = self._find_provider(spec, self_index)
                     if replacement:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -958,7 +958,8 @@ class Spec(object):
         self._concrete = kwargs.get('concrete', False)
 
         # Allow a spec to be constructed with an external path.
-        self.external = kwargs.get('external', None)
+        self.external = kwargs.get('external', False)
+        self.external_path = kwargs.get('external_path', None)
         self.external_module = kwargs.get('external_module', None)
 
         # This allows users to construct a spec DAG with literals.
@@ -1355,7 +1356,7 @@ class Spec(object):
 
         if self.external:
             d['external'] = {
-                'path': self.external,
+                'path': self.external_path,
                 'module': bool(self.external_module)
             }
 
@@ -1423,18 +1424,24 @@ class Spec(object):
                 spec.compiler_flags[name] = []
 
         if 'external' in node:
-            spec.external = None
+            spec.external_path = None
+            spec.external_module = None
             # This conditional is needed because sometimes this function is
             # called with a node already constructed that contains a 'versions'
             # and 'external' field. Related to virtual packages provider
             # indexes.
             if node['external']:
-                spec.external = node['external']['path']
+                spec.external_path = node['external']['path']
                 spec.external_module = node['external']['module']
                 if spec.external_module is False:
                     spec.external_module = None
+                spec.external = True
+            else:
+                spec.external = False
         else:
-            spec.external = None
+            spec.external = False
+            spec.external_path = None
+            spec.external_module = None
 
         # Don't read dependencies here; from_node_dict() is used by
         # from_yaml() to read the root *and* each dependency spec.
@@ -1638,7 +1645,7 @@ class Spec(object):
                             continue
 
                 # If replacement is external then trim the dependencies
-                if replacement.external or replacement.external_module:
+                if replacement.external:
                     if (spec._dependencies):
                         changed = True
                         spec._dependencies = DependencyMap()
@@ -1657,6 +1664,8 @@ class Spec(object):
                         feq(replacement._dependencies, spec._dependencies) and
                         feq(replacement.variants, spec.variants) and
                         feq(replacement.external, spec.external) and
+                        feq(replacement.external_module,
+                            spec.external_module) and
                         feq(replacement.external_module,
                             spec.external_module)):
                     continue
@@ -1722,7 +1731,7 @@ class Spec(object):
                 for mod in compiler.modules:
                     load_module(mod)
 
-                s.external = get_path_from_module(s.external_module)
+                s.external_path = get_path_from_module(s.external_module)
 
         # Mark everything in the spec as concrete, as well.
         self._mark_concrete()
@@ -1931,7 +1940,7 @@ class Spec(object):
 
         # if we descend into a virtual spec, there's nothing more
         # to normalize.  Concretize will finish resolving it later.
-        if self.virtual or self.external or self.external_module:
+        if self.virtual or self.external:
             return False
 
         # Combine constraints from package deps with constraints from
@@ -2338,6 +2347,7 @@ class Spec(object):
                        self._normal != other._normal and
                        self.concrete != other.concrete and
                        self.external != other.external and
+                       self.external_path != other.external_path and
                        self.external_module != other.external_module and
                        self.compiler_flags != other.compiler_flags)
 
@@ -2354,6 +2364,7 @@ class Spec(object):
         self.variants = other.variants.copy()
         self.variants.spec = self
         self.external = other.external
+        self.external_path = other.external_path
         self.external_module = other.external_module
         self.namespace = other.namespace
 
@@ -3000,7 +3011,8 @@ class SpecParser(spack.parse.Parser):
         spec.variants = VariantMap(spec)
         spec.architecture = None
         spec.compiler = None
-        spec.external = None
+        spec.external = False
+        spec.external_path = None
         spec.external_module = None
         spec.compiler_flags = FlagMap(spec)
         spec._dependents = DependencyMap()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1609,6 +1609,9 @@ class Spec(object):
             done = True
             for spec in list(self.traverse()):
                 replacement = None
+                if spec.external:
+                    done = True
+                    break
                 if spec.virtual:
                     replacement = self._find_provider(spec, self_index)
                     if replacement:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1438,11 +1438,7 @@ class Spec(object):
                 spec.external_module = node['external']['module']
                 if spec.external_module is False:
                     spec.external_module = None
-                spec.external = True
-            else:
-                spec.external = False
         else:
-            spec.external = False
             spec.external_path = None
             spec.external_module = None
 
@@ -1668,9 +1664,8 @@ class Spec(object):
                         feq(replacement.architecture, spec.architecture) and
                         feq(replacement._dependencies, spec._dependencies) and
                         feq(replacement.variants, spec.variants) and
-                        feq(replacement.external, spec.external) and
-                        feq(replacement.external_module,
-                            spec.external_module) and
+                        feq(replacement.external_path,
+                            spec.external_path) and
                         feq(replacement.external_module,
                             spec.external_module)):
                     continue

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -958,7 +958,6 @@ class Spec(object):
         self._concrete = kwargs.get('concrete', False)
 
         # Allow a spec to be constructed with an external path.
-        self.external = kwargs.get('external', False)
         self.external_path = kwargs.get('external_path', None)
         self.external_module = kwargs.get('external_module', None)
 
@@ -980,6 +979,10 @@ class Spec(object):
             spec = dep if isinstance(dep, Spec) else Spec(dep)
             self._add_dependency(spec, deptypes)
             deptypes = ()
+
+    @property
+    def external(self):
+        return bool(self.external_path) or bool(self.external_module)
 
     def get_dependency(self, name):
         dep = self._dependencies.get(name)
@@ -2348,7 +2351,6 @@ class Spec(object):
                        self.variants != other.variants and
                        self._normal != other._normal and
                        self.concrete != other.concrete and
-                       self.external != other.external and
                        self.external_path != other.external_path and
                        self.external_module != other.external_module and
                        self.compiler_flags != other.compiler_flags)
@@ -2365,7 +2367,6 @@ class Spec(object):
         self.compiler_flags = other.compiler_flags.copy()
         self.variants = other.variants.copy()
         self.variants.spec = self
-        self.external = other.external
         self.external_path = other.external_path
         self.external_module = other.external_module
         self.namespace = other.namespace

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -276,7 +276,7 @@ class TestConcretize(object):
     def test_external_package(self):
         spec = Spec('externaltool%gcc')
         spec.concretize()
-        assert spec['externaltool'].external == '/path/to/external_tool'
+        assert spec['externaltool'].external_path == '/path/to/external_tool'
         assert 'externalprereq' not in spec
         assert spec['externaltool'].compiler.satisfies('gcc')
 
@@ -305,8 +305,8 @@ class TestConcretize(object):
     def test_external_and_virtual(self):
         spec = Spec('externaltest')
         spec.concretize()
-        assert spec['externaltool'].external == '/path/to/external_tool'
-        assert spec['stuff'].external == '/path/to/external_virtual_gcc'
+        assert spec['externaltool'].external_path == '/path/to/external_tool'
+        assert spec['stuff'].external_path == '/path/to/external_virtual_gcc'
         assert spec['externaltool'].compiler.satisfies('gcc')
         assert spec['stuff'].compiler.satisfies('gcc')
 

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -170,4 +170,4 @@ mpich:
         # ensure that once config is in place, external is used
         spec = Spec('mpi')
         spec.concretize()
-        assert spec['mpich'].external == '/dummy/path'
+        assert spec['mpich'].external_path == '/dummy/path'

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -89,12 +89,12 @@ def _check_db_sanity(install_db):
     pkg_in_layout = sorted(spack.store.layout.all_specs())
     actual = sorted(install_db.query())
 
-    externals = sorted([x for x in actual if x.external is not None])
+    externals = sorted([x for x in actual if x.external is True])
     nexpected = len(pkg_in_layout) + len(externals)
 
     assert nexpected == len(actual)
 
-    non_external_in_db = sorted([x for x in actual if x.external is None])
+    non_external_in_db = sorted([x for x in actual if x.external is False])
 
     for e, a in zip(pkg_in_layout, non_external_in_db):
         assert e == a
@@ -377,16 +377,16 @@ def test_external_entries_in_db(database):
     install_db = database.mock.db
 
     rec = install_db.get_record('mpileaks ^zmpi')
-    assert rec.spec.external is None
+    assert rec.spec.external_path is None
     assert rec.spec.external_module is None
 
     rec = install_db.get_record('externaltool')
-    assert rec.spec.external == '/path/to/external_tool'
+    assert rec.spec.external_path == '/path/to/external_tool'
     assert rec.spec.external_module is None
     assert rec.explicit is False
 
     rec.spec.package.do_install(fake=True, explicit=True)
     rec = install_db.get_record('externaltool')
-    assert rec.spec.external == '/path/to/external_tool'
+    assert rec.spec.external_path == '/path/to/external_tool'
     assert rec.spec.external_module is None
     assert rec.explicit is True


### PR DESCRIPTION
Some highlights:

- I change spec.external to be a simple boolean and add spec.external_path

- I add some more debug messages

- There's no need to find the external module path during every loop of concreization..

- A loop can happen during concretization where an external spec which is not concrete is used for a package. This package is then concretized furthur. That spec is then tested to see whether an external spec matches it, and the old unconcretized spec replaces the one we just concretized thus starting an infinite loop.
