### PR TITLE
Changed python path that are wrong or missing

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -93,6 +93,13 @@ class Lammps(CMakePackage):
 
     root_cmakelists_dir = 'cmake'
 
+    def setup_environment(self, spack_env, run_env):
+        if '+python' in self.spec:
+            run_env.prepend_path('PYTHONPATH', join_path(
+                self.prefix.lib,
+                'python{0}'.format(self.spec['python'].version.up_to(2)),
+                'site-packages'))
+            
     def cmake_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -112,12 +112,10 @@ class Paraview(CMakePackage):
         run_env.prepend_path('LD_LIBRARY_PATH', join_path(lib_dir,
                              paraview_version))
         if '+python' in self.spec:
-            run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
-                                 paraview_version))
-            run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
-                                 paraview_version, 'site-packages'))
-            run_env.prepend_path('PYTHONPATH', join_path(lib_dir,
-                                 paraview_version, 'site-packages', 'vtk'))
+            run_env.prepend_path('PYTHONPATH', join_path(
+                self.prefix.lib,
+                'python{0}'.format(self.spec['python'].version.up_to(2)),
+                'site-packages'))
 
     def cmake_args(self):
         """Populate cmake arguments for ParaView."""


### PR DESCRIPTION
This should perhpas be done with extends('python') on upstream

But this wayt it avoids recompiling the packages for already deployed softs
`site_packages_dir` is not accessible in setup_environment...