### PR TITLE
changing the target detection

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-com/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-com/package.py
@@ -62,6 +62,7 @@ import glob
 import re
 import shutil
 import os
+import platform as py_platform
 
 from spack import *
 from spack.environment import EnvironmentModifications
@@ -757,8 +758,8 @@ class OpenfoamArch(object):
         # spec.architecture.platform is like `uname -s`, but lower-case
         platform = spec.architecture.platform
 
-        # spec.architecture.target is like `uname -m`
-        target   = spec.architecture.target
+        # do not use spec.architecture.target it fails if SPACK_TARGET_TYPE is set
+        target   = py_platform.machine()
 
         if platform == 'linux':
             if target == 'i686':


### PR DESCRIPTION
The detection of the architecture uses spec.architecture.target that contains scitas specific sys types.
That makes *foam* detection fail