### PR TITLE
Packages/paien/tophat

### DIFF
--- a/var/spack/repos/builtin/packages/tophat/package.py
+++ b/var/spack/repos/builtin/packages/tophat/package.py
@@ -26,23 +26,31 @@ from spack import *
 
 
 class Tophat(AutotoolsPackage):
-    """TopHat is a fast splice junction mapper for RNA-Seq reads.
+    """TopHat is a fast splice junction read mapper for RNA-Seq.
 
      It aligns RNA-Seq reads to mammalian-sized genomes using the ultra
      high-throughput short read aligner Bowtie, and then analyzes the
      the mapping results to identify splice junctions between exons."""
 
-    homepage = "https://ccb.jhu.edu/software/tophat/index.shtml"
-    url      = "https://ccb.jhu.edu/software/tophat/downloads/tophat-2.1.1.tar.gz"
+    homepage = "http://ccb.jhu.edu/software/tophat/index.shtml"
+    url      = "https://github.com/infphilo/tophat/archive/v2.1.1.tar.gz"
 
-    version('2.1.1', '4b2391de46457ba6b2b7268a9da593e4')
+    version('2.1.2', 'db844fd7f53c519e716cd6222e6195b2')
+    version('2.1.1', 'ffd18de2f893a95eb7e9d0c5283d241f')
+
+    depends_on('autoconf', type='build')
+    # 2.1.1 only builds with automake@1.15.1.  There's a patch here:
+    # https://github.com/spack/spack/pull/8244, which was incorporated
+    # upstream in 2.1.2, which is known to build with 1.16.1 and 1.15.1.
+    depends_on('automake',                        type='build')
+    depends_on('automake@1.15.1', when='@:2.1.1', type='build')
+    depends_on('libtool',  type='build')
+    depends_on('m4',       type='build')
 
     depends_on('boost@1.47:')
-    depends_on('ncurses')
     depends_on('bowtie2', type='run')
 
     parallel = False
 
     def configure_args(self):
-        args = ['--with-boost=%s' % self.spec['boost'].prefix]
-        return args
+        return ["--with-boost={0}".format(self.spec['boost'].prefix)]

--- a/var/spack/repos/builtin/packages/tophat/package.py
+++ b/var/spack/repos/builtin/packages/tophat/package.py
@@ -26,22 +26,19 @@ from spack import *
 
 
 class Tophat(AutotoolsPackage):
-    """Spliced read mapper for RNA-Seq."""
+    """TopHat is a fast splice junction mapper for RNA-Seq reads.
 
-    homepage = "http://ccb.jhu.edu/software/tophat/index.shtml"
-    url      = "https://github.com/infphilo/tophat/archive/v2.1.1.tar.gz"
+     It aligns RNA-Seq reads to mammalian-sized genomes using the ultra
+     high-throughput short read aligner Bowtie, and then analyzes the
+     the mapping results to identify splice junctions between exons."""
 
-    version('2.1.1', 'ffd18de2f893a95eb7e9d0c5283d241f')
+    homepage = "https://ccb.jhu.edu/software/tophat/index.shtml"
+    url      = "https://ccb.jhu.edu/software/tophat/downloads/tophat-2.1.1.tar.gz"
 
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-    depends_on('libtool',  type='build')
-    depends_on('m4',       type='build')
+    version('2.1.1', '4b2391de46457ba6b2b7268a9da593e4')
 
-    depends_on('boost@1.47:')
-    depends_on('bowtie2', type='run')
-
-    parallel = False
+    depends_on('boost')
 
     def configure_args(self):
-        return ["--with-boost={0}".format(self.spec['boost'].prefix)]
+        args = ['--with-boost=%s' % self.spec['boost'].prefix]
+        return args

--- a/var/spack/repos/builtin/packages/tophat/package.py
+++ b/var/spack/repos/builtin/packages/tophat/package.py
@@ -37,7 +37,11 @@ class Tophat(AutotoolsPackage):
 
     version('2.1.1', '4b2391de46457ba6b2b7268a9da593e4')
 
-    depends_on('boost')
+    depends_on('boost@1.47:')
+    depends_on('ncurses')
+    depends_on('bowtie2', type='run')
+
+    parallel = False
 
     def configure_args(self):
         args = ['--with-boost=%s' % self.spec['boost'].prefix]


### PR DESCRIPTION
TopHat package release 2.1.2 - Splice junction read mapper for RNA-Seq.

NOTE: this package cannot compile with C++ standards std c++ >11.